### PR TITLE
🚀 chore: remove outdated Go package installations from setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,10 +21,8 @@ source "$HOME/.zshrc"
 
 go install github.com/cloudflare/cfssl/cmd/...@latest
 go install github.com/goreleaser/goreleaser/v2@latest
-go install github.com/monasticacademy/httptap@latest
 go install github.com/pamelia/git-crypt@latest
 go install github.com/spf13/cobra-cli@latest
-go install sigs.k8s.io/kind@latest
 
 if ! command -v spf >/dev/null 2>&1; then
     bash -c "$(curl -sLo- https://superfile.netlify.app/install.sh)"


### PR DESCRIPTION
### Pull Request Description

This pull request focuses on cleaning up the `setup.sh` script by removing outdated Go package installations. The goal of this change is to streamline the setup process and ensure that only currently relevant packages are included, which should help improve the overall efficiency and maintainability of the project.

#### Changes Made:
- Removed outdated Go package installations that are no longer necessary for the setup.

This improvement should make it easier for new contributors to set up the project without encountering issues related to deprecated packages.